### PR TITLE
Fix text() for incomplete LaTeX commands

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -357,9 +357,9 @@ var MathBlock = P(MathElement, function(_, super_) {
   _.html = function() { return this.join('html'); };
   _.latex = function() { return this.join('latex'); };
   _.text = function() {
-    return this.ends[L] === this.ends[R] ?
+    return (this.ends[L] === this.ends[R] && this.ends[L] !== 0) ?
       this.ends[L].text() :
-      '(' + this.join('text') + ')'
+      this.join('text')
     ;
   };
 

--- a/src/css/selections.less
+++ b/src/css/selections.less
@@ -15,6 +15,7 @@
       background: Highlight !important;
       color: HighlightText;
       border-color: HighlightText;
+      display: inline-block;
     }
 
     .mq-matrixed {

--- a/src/css/selections.less
+++ b/src/css/selections.less
@@ -15,7 +15,6 @@
       background: Highlight !important;
       color: HighlightText;
       border-color: HighlightText;
-      display: inline-block;
     }
 
     .mq-matrixed {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -102,7 +102,9 @@ suite('Public API', function() {
       assert.equal(mq.text(), '');
       mq.typedText('\\');
       assert.equal(mq.text(), '\\');
-      mq.typedText('sqrt');
+      mq.typedText('s');
+      assert.equal(mq.text(), '\\s');
+      mq.typedText('qrt');
       assert.equal(mq.text(), '\\sqrt');
     });
     

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -97,6 +97,31 @@ suite('Public API', function() {
       mq.latex('x+y');
       assert.equal(mq.html(), '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>');
     });
+    
+    test('.text() with incomplete commands', function() {
+      assert.equal(mq.text(), '');
+      mq.typedText('\\');
+      assert.equal(mq.text(), '\\');
+      mq.typedText('sqrt');
+      assert.equal(mq.text(), '\\sqrt');
+    });
+    
+    test('.text() with complete commands', function() {
+      mq.latex('\\sqrt{}');
+      assert.equal(mq.text(), 'sqrt()');
+      mq.latex('\\nthroot[]{}');
+      assert.equal(mq.text(), 'sqrt[]()');
+      mq.latex('\\frac{}{}');
+      assert.equal(mq.text(), '(/)');
+      mq.latex('\\frac{3}{5}');
+      assert.equal(mq.text(), '(3/5)');
+      mq.latex('\\div');
+      assert.equal(mq.text(), '[/]');
+      mq.latex('^{}');
+      assert.equal(mq.text(), '**');
+      mq.latex('3^{4}');
+      assert.equal(mq.text(), '3**4');
+    });
 
     test('.moveToDirEnd(dir)', function() {
       mq.latex('a x^2 + b x + c = 0');


### PR DESCRIPTION
If you called text() on an editable field where the user has entered a backslash but hasn’t completed a LaTeX template, the backslash command’s text() method would throw an error when trying to call text() on the MathBlock’s undefined ends[L]. Subsequent keystrokes would then occur outside the template.

This commit ensures that the text() method works when an editable field contains a backslash that hasn’t been converted into a LaTeX template. If the editable field contains ‘\’ or part of a LaTeX command like ‘\sqr’, text() will return what the user has typed literally (‘\’ and ‘\sqr’, respectively).