### PR TITLE
Add prevent spaces from behaving like tabs in root blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ Global defaults for a page may be set with `MathQuill.config({ ... })`.
 
 If `spaceBehavesLikeTab` is true the keystrokes {Shift-,}Spacebar will behave
 like {Shift-,}Tab escaping from the current block (as opposed to the default
-behavior of inserting a Space character).
+behavior of inserting a Space character). If `spaceBehavesLikeTab` is
+`'exceptRootBlock'` the keystrokes will behave as true for all blocks that are
+not the root block.  This option allows the entering of mixed fractions in the
+root block, where true does not.
 
 By default, the Left and Right keys move the cursor through all possible cursor
 positions in a particular order: right into a fraction puts the cursor at the

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -364,7 +364,7 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 
   _.keystroke = function(key, e, ctrlr) {
-    if (ctrlr.API.__options.spaceBehavesLikeTab
+    if ((ctrlr.API.__options.spaceBehavesLikeTab === true || (ctrlr.API.__options.spaceBehavesLikeTab === 'exceptRootBlock' && this.parent !== 0))
         && (key === 'Spacebar' || key === 'Shift-Spacebar')) {
       e.preventDefault();
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -349,6 +349,49 @@ suite('Public API', function() {
 
       $(mq.el()).remove();
     });
+    test('space behaves like tab when spaceBehavesLikeTab is exceptRootBlock', function() {
+      var opts = { 'spaceBehavesLikeTab': 'exceptRootBlock' };
+      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts);
+      rootBlock = mq.__controller.root;
+      cursor = mq.__controller.cursor;
+
+      mq.typedText('1 1/2');
+      assert.equal(mq.latex(), '1\\ \\frac{1}{2}', 'latex is ' + mq.latex());
+
+      mq.typedText(' ');
+      assert.equal(cursor[R], 0, 'right cursor is ' + cursor[R]);
+
+      $(mq.el()).remove();
+    });
+    test('space behaves like tab when globally set to exceptRootBlock', function() {
+      MathQuill.config({ spaceBehavesLikeTab: 'exceptRootBlock' });
+
+      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0]);
+      rootBlock = mq.__controller.root;
+      cursor = mq.__controller.cursor;
+
+      mq.typedText('1 1/2');
+      assert.equal(mq.latex(), '1\\ \\frac{1}{2}', 'latex is ' + mq.latex());
+
+      mq.typedText(' ');
+      assert.equal(cursor[R], 0, 'right cursor is ' + cursor[R]);
+
+      $(mq.el()).remove();
+    });
+    test('compare latex for space behaves like tab true to exceptRootBlock', function() {
+      var opts = { 'spaceBehavesLikeTab': 'exceptRootBlock' };
+      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts);
+      mq.typedText('1/2 ');
+
+      var opts2 = { 'spaceBehavesLikeTab': true };
+      var mq2 = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts2);
+      mq2.typedText('1/2 ');
+
+      assert.equal(mq.latex(), mq2.latex(), 'latex should be the same ' + '\'' + mq.latex() + '\' and \'' + mq2.latex() + '\'');
+
+      $(mq.el()).remove();
+      $(mq2.el()).remove();
+    });
   });
 
   suite('statelessClipboard option', function() {


### PR DESCRIPTION
This commit adds another configuration parameter for the spaceBehavesLikeTab
option.  Previously, the only valid values were 'true' and 'false'.  Where
'false' simply inserted spaces and 'true' made spaces behave like tab.  It is
now possible to add a string 'exceptRootBlock'.  'exceptRootBlock' behaves
the same as 'true' unless the cursor is in the root block, where it will
insert a space instead.

This feature allows the entry of mixed fractions in the root block, which
'true' was unable to do.

This feature is purposfully overloading the semantics of 'spaceBehavesLikeTab'
to add a new configuration option because this causes the smallest divergeance
from the MathQuill root project.  All things being equal, however, the better
change would be to rename the configuration option to 'spaceBehavior' and use
strings for all options: 'default', 'asSpaces', 'asTabs', and
'asTabsExceptForRootBlock'.  Where 'default' and 'asSpaces' are currently the
same.