### PR TITLE
Add bower and grunt support.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,9 @@ module.exports = function(grunt) {
             build: {
                 command: 'make'
             },
+            test: {
+                command: 'make test'
+            },
             clean: {
                 command: 'make clean'
             }
@@ -35,6 +38,10 @@ module.exports = function(grunt) {
 
     grunt.registerTask('clean', [
         'shell:clean'
+    ]);
+
+    grunt.registerTask('test', [
+        'shell:test'
     ]);
 
     grunt.registerTask('publish', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,45 @@
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        shell: {
+            options: {
+                stdout: true,
+                execOptions: {
+                    maxBuffer: Infinity
+                }                
+            },
+            build: {
+                command: 'make'
+            },
+            clean: {
+                command: 'make clean'
+            }
+        },
+        copy: {
+            bower: {
+                cwd: '.',
+                src: 'bower.json',
+                dest: 'build/bower.json'
+            }
+        },
+        'release-bower': {
+            options: {
+                scanPath: 'build'
+            }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-shell');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-release-bower');
+
+    grunt.registerTask('clean', [
+        'shell:clean'
+    ]);
+
+    grunt.registerTask('publish', [
+        'shell:build',
+        'copy:bower',
+        'release-bower'
+    ]);
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,40 @@
+{
+  "name": "apollo-ctp-mathquill",
+  "version": "0.9.4",
+  "homepage": "https://github.com/apollo-ctp/mathquill",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/apollo-ctp/mathquill.git"
+  },
+  "authors": [
+    "Original MathQuill Authors",
+    "Karl Schaefer <kschaefer@carnegielearning.com>",
+    "Andreya Piplica <apiplica@carnegielearning.com>"
+  ],
+  "description": "LaTeX-based editable math fields",
+  "main": [
+    "build/mathquill.js",
+    "build/mathquill.css",
+    "build/font/*"
+  ],
+  "dependencies": {
+    "jquery": "^1.4.3"
+  },
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "mathquill",
+    "latex",
+    "math",
+    "editor"
+  ],
+  "license": "MPL-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "src"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
     "pjs": "3.x"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-copy": "^0.8.1",
+    "grunt-shell": "^1.1.2",
+    "less": ">=1.5.1",
     "mocha": "*",
-    "uglify-js": "2.x",
-    "less": ">=1.5.1"
+    "uglify-js": "2.x"
   }
 }


### PR DESCRIPTION
Add grunt to manage bower distributions.  This shells out to ‘make’ as
much as possible to keep the distributions between core and bower
distributions the same.