### PR TITLE
Fix unit tests for selection

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -12,6 +12,7 @@ JS environment could actually contain many instances. */
 //A fake cursor in the fake textbox that the math is rendered in.
 var Cursor = P(Point, function(_) {
   _.init = function(initParent, options) {
+    pray('options must be a valid object: ' + options, typeof options === 'object' && options !== null);
     this.parent = initParent;
     this.options = options;
 
@@ -223,8 +224,8 @@ var Cursor = P(Point, function(_) {
     if (leftEnd instanceof Point) leftEnd = leftEnd[R];
     if (rightEnd instanceof Point) rightEnd = rightEnd[L];
 
-		// adjust selections for strict operators
-		var strictOperators = this.options.strictOperatorSelection;
+    // adjust selections for strict operators
+    var strictOperators = this.options.strictOperatorSelection;
     if (strictOperators !== undefined) {
       var isPrefixOp = function(ctrlSeq) {
         return strictOperators.prefixOperators &&

--- a/test/unit/select.test.js
+++ b/test/unit/select.test.js
@@ -1,5 +1,5 @@
 suite('Cursor::select()', function() {
-  var cursor = Cursor();
+  var cursor = Cursor(0, {});
   cursor.selectionChanged = noop;
 
   function assertSelection(A, B, leftEnd, rightEnd) {


### PR DESCRIPTION
The strictOperator selection pieces require that Cursor have a valid
options.  This simply means that we have to pass an options object into
the constructor.  The unit test previously left the constructor empty,
so this is a simple fix.  Also added a prayer for a valid object in
Cursor to make it easier to find this type of error in the future.

Since it does not seem to be the approach of MathQuill to use default
values in constructor, this was avoided.  This could have also been
solved by:
this.options = options || {};